### PR TITLE
Don't push events with malformed p tags to strfry

### DIFF
--- a/internal/fixtures/fixtures.go
+++ b/internal/fixtures/fixtures.go
@@ -177,6 +177,10 @@ func SomeRelayAddress() domain.RelayAddress {
 	return v
 }
 
+func SomeEventKind() domain.EventKind {
+	return internal.RandomElement([]domain.EventKind{domain.EventKindNote, domain.EventKindContacts})
+}
+
 func SomeMaybeRelayAddress() domain.MaybeRelayAddress {
 	return domain.NewMaybeRelayAddress(SomeString())
 }

--- a/service/app/handler_process_saved_event.go
+++ b/service/app/handler_process_saved_event.go
@@ -192,6 +192,10 @@ func (h *ProcessSavedEventHandler) shouldSendEventToRelay(event domain.Event) bo
 		return false
 	}
 
+	if event.HasInvalidProfileTags() {
+		return false
+	}
+
 	return true
 }
 
@@ -200,8 +204,6 @@ func (h *ProcessSavedEventHandler) shouldDisregardSendEventErr(err error) bool {
 	if errors.As(err, &okResponseErr) {
 		switch okResponseErr.Reason() {
 		case "replaced: have newer event":
-			return true
-		case "invalid: uneven size input to from_hex":
 			return true
 		default:
 			return false

--- a/service/domain/event.go
+++ b/service/domain/event.go
@@ -104,6 +104,19 @@ func (e Event) Tags() []EventTag {
 	return internal.CopySlice(e.tags)
 }
 
+func (e Event) HasInvalidProfileTags() bool {
+	for _, tag := range e.tags {
+		if !tag.IsProfile() {
+			continue
+		}
+
+		if _, err := tag.Profile(); err != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (e Event) Content() string {
 	return e.content
 }

--- a/service/domain/event_test.go
+++ b/service/domain/event_test.go
@@ -1,0 +1,55 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/planetary-social/nos-event-service/internal/fixtures"
+	"github.com/planetary-social/nos-event-service/service/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvent_HasInvalidProfileTags(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Event  domain.Event
+		Result bool
+	}{
+		{
+			Name:   "no_tags",
+			Event:  fixtures.Event(fixtures.SomeEventKind(), nil, fixtures.SomeString()),
+			Result: false,
+		},
+		{
+			Name: "malformed_tag",
+			Event: fixtures.Event(
+				fixtures.SomeEventKind(),
+				[]domain.EventTag{
+					domain.MustNewEventTag([]string{
+						"p", "something",
+					}),
+				},
+				fixtures.SomeString(),
+			),
+			Result: true,
+		},
+		{
+			Name: "correct_tag",
+			Event: fixtures.Event(
+				fixtures.SomeEventKind(),
+				[]domain.EventTag{
+					domain.MustNewEventTag([]string{
+						"p", fixtures.SomePublicKey().Hex(),
+					}),
+				},
+				fixtures.SomeString(),
+			),
+			Result: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			require.Equal(t, testCase.Result, testCase.Event.HasInvalidProfileTags())
+		})
+	}
+}


### PR DESCRIPTION
They will be rejected anyway, our previous error-based method of detecting this was flawed and silly.