### PR TITLE
Lower max backoff when processing events

### DIFF
--- a/service/adapters/sqlite/pubsub.go
+++ b/service/adapters/sqlite/pubsub.go
@@ -357,7 +357,7 @@ func (p *TxPubSub) PublishTx(topic string, msg Message) error {
 }
 
 const (
-	maxDefaultMessageErrorBackoff = 6 * time.Hour
+	maxDefaultMessageErrorBackoff = 1 * time.Hour
 	maxDefaultNoMessagesBackoff   = 30 * time.Second
 
 	randomizeMessageErrorBackoffByFraction = 0.1


### PR DESCRIPTION
Reason: it is boring to wait 6 hours for messages to be consumed and see if your fix worked.