### PR TITLE
Fix incorrect left join

### DIFF
--- a/service/adapters/sqlite/contact_repository.go
+++ b/service/adapters/sqlite/contact_repository.go
@@ -108,8 +108,8 @@ func (r *ContactRepository) GetCurrentContactsEvent(ctx context.Context, author 
 	row := r.tx.QueryRow(`
 		SELECT E.payload
 		FROM public_keys PK
-		LEFT JOIN contacts_events CE ON CE.follower_id=PK.id
-		LEFT JOIN events E ON E.id=CE.event_id
+		INNER JOIN contacts_events CE ON CE.follower_id=PK.id
+		INNER JOIN events E ON E.id=CE.event_id
 		WHERE PK.public_key=$1`,
 		author.Hex(),
 	)


### PR DESCRIPTION
We can have entries in public_keys but not contacts_events if the public key is a followee not a follower.