### PR TITLE
Avoid loading events for no reason

### DIFF
--- a/service/adapters/sqlite/event_repository.go
+++ b/service/adapters/sqlite/event_repository.go
@@ -57,6 +57,24 @@ func (r *EventRepository) Count(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+func (r *EventRepository) Exists(ctx context.Context, eventID domain.EventId) (bool, error) {
+	result := r.tx.QueryRow(`
+	SELECT event_id
+	FROM events
+	WHERE event_id=$1`,
+		eventID.Hex(),
+	)
+
+	var tmp string
+	if err := result.Scan(&tmp); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "error scanning")
+	}
+	return true, nil
+}
+
 func (m *EventRepository) readEvent(result *sql.Row) (domain.Event, error) {
 	var payload []byte
 

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -33,6 +33,7 @@ type EventRepository interface {
 	// Get returns ErrEventNotFound.
 	Get(ctx context.Context, eventID domain.EventId) (domain.Event, error)
 
+	Exists(ctx context.Context, eventID domain.EventId) (bool, error)
 	Count(ctx context.Context) (int, error)
 }
 

--- a/service/app/handler_save_received_event.go
+++ b/service/app/handler_save_received_event.go
@@ -62,7 +62,7 @@ func (h *SaveReceivedEventHandler) Handle(ctx context.Context, cmd SaveReceivedE
 	}
 
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {
-		exists, err := h.eventAlreadyExists(ctx, adapters, cmd.event)
+		exists, err := adapters.Events.Exists(ctx, cmd.event.Id())
 		if err != nil {
 			return errors.Wrap(err, "error checking if event exists")
 		}
@@ -99,17 +99,6 @@ func (h *SaveReceivedEventHandler) Handle(ctx context.Context, cmd SaveReceivedE
 	}
 
 	return nil
-}
-
-func (h *SaveReceivedEventHandler) eventAlreadyExists(ctx context.Context, adapters Adapters, event domain.Event) (bool, error) {
-	if _, err := adapters.Events.Get(ctx, event.Id()); err != nil {
-		if errors.Is(err, ErrEventNotFound) {
-			return false, nil
-		}
-		return false, errors.Wrap(err, "error checking if event exists")
-	}
-
-	return true, nil
 }
 
 func (h *SaveReceivedEventHandler) shouldBeDownloaded(ctx context.Context, adapters Adapters, event domain.Event) (bool, error) {


### PR DESCRIPTION
Checking signatures (which we probably want to do to catch bugs and data integrity problems?) is expensive.