### PR TITLE
Add _health endpoint

### DIFF
--- a/service/ports/http/http.go
+++ b/service/ports/http/http.go
@@ -65,6 +65,7 @@ func (s *Server) createMux() http.Handler {
 	r.HandleFunc("/events", rest.Wrap(s.serveEvents))
 	r.HandleFunc("/events/{id}", rest.Wrap(s.serveEvent))
 	r.HandleFunc("/public-keys/{hex}", rest.Wrap(s.servePublicKey))
+	r.HandleFunc("/_health", rest.Wrap(s.serveHealthCheck))
 	r.HandleFunc("/", s.serveWs)
 	return r
 }
@@ -183,6 +184,7 @@ func newGetEventResponse(event domain.Event) getEventResponse {
 	return getEventResponse{Event: event.Raw()}
 }
 
+
 func (s *Server) servePublicKey(r *http.Request) rest.RestResponse {
 	vars := mux.Vars(r)
 	hexPublicKeyString := vars["hex"]
@@ -211,6 +213,12 @@ func newGetPublicKeyResponse(info app.PublicKeyInfo) *getPublicKeyResponse {
 		Followers: info.NumberOfFollowers(),
 		Followees: info.NumberOfFollowees(),
 	}
+}
+
+// The beginning of a health endpoint.  Literally just shows that the server
+// is running and handling requests.  Our metrics give more detailed health info.
+func (s *Server) serveHealthCheck( r *http.Request ) rest.RestResponse {
+	return rest.NewResponse("ok")
 }
 
 func (s *Server) handleConnection(ctx context.Context, conn *websocket.Conn) error {

--- a/service/ports/http/http.go
+++ b/service/ports/http/http.go
@@ -217,7 +217,7 @@ func newGetPublicKeyResponse(info app.PublicKeyInfo) *getPublicKeyResponse {
 
 // The beginning of a health endpoint.  Literally just shows that the server
 // is running and handling requests.  Our metrics give more detailed health info.
-func (s *Server) serveHealthCheck( r *http.Request ) rest.RestResponse {
+func (s *Server) serveHealthCheck(r *http.Request) rest.RestResponse {
 	return rest.NewResponse("ok")
 }
 

--- a/service/ports/http/http.go
+++ b/service/ports/http/http.go
@@ -184,7 +184,6 @@ func newGetEventResponse(event domain.Event) getEventResponse {
 	return getEventResponse{Event: event.Raw()}
 }
 
-
 func (s *Server) servePublicKey(r *http.Request) rest.RestResponse {
 	vars := mux.Vars(r)
 	hexPublicKeyString := vars["hex"]


### PR DESCRIPTION
This adds a basic healthcheck endpoint at /_health.  At the moment, it only shows that the server is up and running and handling requests.  I think this is okay, though, as the event service has more detailed metrics, and existing alerts from these, to give a more detailed look at the application's health.  This endpoint can be used as a simple uptime alert to check the status of the service itself.

I tried to follow the pattern of the existing code, and so wrapped the check as a json response using boreq's rest library.