### PR TITLE
Handle closed messages

### DIFF
--- a/service/domain/relays/relay_connections.go
+++ b/service/domain/relays/relay_connections.go
@@ -30,6 +30,7 @@ var (
 	MessageTypeEvent   = MessageType{"event"}
 	MessageTypeAuth    = MessageType{"auth"}
 	MessageTypeOK      = MessageType{"ok"}
+	MessageTypeClose   = MessageType{"close"}
 	MessageTypeUnknown = MessageType{"unknown"}
 )
 


### PR DESCRIPTION
Let's handle CLOSED messages instead of creating errors for them. I think this is one of the causes for our big number of rejected publications that is increasing the message queue.