### PR TITLE
More validations and check it before push to queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ThreeDotsLabs/watermill-googlecloud v1.0.13
 	github.com/boreq/errors v0.1.0
 	github.com/boreq/rest v0.1.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/mux v1.8.1
@@ -36,7 +37,6 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/service/app/filter.go
+++ b/service/app/filter.go
@@ -60,5 +60,5 @@ type Event interface {
 	Kind() domain.EventKind
 	Tags() []domain.EventTag
 	Raw() []byte
-	HasInvalidProfileTags() bool
+	IsInvalid() bool
 }

--- a/service/app/handler_process_saved_event.go
+++ b/service/app/handler_process_saved_event.go
@@ -66,6 +66,7 @@ func NewProcessSavedEventHandler(
 	}
 }
 
+// This processes the internal db based event queue, the event is already in the database
 func (h *ProcessSavedEventHandler) Handle(ctx context.Context, cmd ProcessSavedEvent) (err error) {
 	defer h.metrics.StartApplicationCall("processSavedEvent").End(&err)
 
@@ -193,7 +194,7 @@ func (h *ProcessSavedEventHandler) maybeSendEventToRelay(ctx context.Context, ev
 }
 
 func (h *ProcessSavedEventHandler) shouldDisregardSendEventErr(err error) bool {
-	return errors.Is(err, relays.ErrEventReplaced)
+	return errors.Is(err, relays.ErrEventReplaced) || errors.Is(err, relays.ErrEventInvalid)
 }
 
 func ShouldSendEventToRelay(event Event) bool {
@@ -206,7 +207,7 @@ func ShouldSendEventToRelay(event Event) bool {
 		return false
 	}
 
-	if event.HasInvalidProfileTags() {
+	if event.IsInvalid() {
 		return false
 	}
 

--- a/service/app/handler_save_received_event.go
+++ b/service/app/handler_save_received_event.go
@@ -47,6 +47,9 @@ func NewSaveReceivedEventHandler(
 	}
 }
 
+// This handler is responsible for saving received events. It checks if the
+// event should be saved and if so, it saves it and publishes the id to the
+// internal db based event queue.
 func (h *SaveReceivedEventHandler) Handle(ctx context.Context, cmd SaveReceivedEvent) (err error) {
 	defer h.metrics.StartApplicationCall("saveReceivedEvent").End(&err)
 

--- a/service/domain/relays/event_sender.go
+++ b/service/domain/relays/event_sender.go
@@ -2,8 +2,6 @@ package relays
 
 import (
 	"context"
-	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/boreq/errors"
@@ -29,13 +27,6 @@ func (s *EventSender) SendEvent(ctx context.Context, address domain.RelayAddress
 	return nil
 }
 
-func say(text string) {
-	cmd := exec.Command("say", text)
-	if err := cmd.Run(); err != nil {
-		// Handle the error if the command fails
-		fmt.Println("Failed to execute say command:", err)
-	}
-}
 func (s *EventSender) maybeConvertError(err error) error {
 	var okResponseErr OKResponseError
 	if !errors.As(err, &okResponseErr) {


### PR DESCRIPTION
This update covers additional scenarios that make the queue grow too much and refines the validation process to prevent premature queue entries. Additionally, it addresses the detection of invalid OK errors (r tags too big) from the relay to prepare to higher demand on the queue once [pubkey registration is done](https://github.com/planetary-social/nos/issues/663). Additionally, logging tools are included to aid in debugging.