### PR TITLE
Rate limit from notice warnings

### DIFF
--- a/cmd/send-all-events-to-relay/main.go
+++ b/cmd/send-all-events-to-relay/main.go
@@ -339,3 +339,6 @@ func (m mockMetrics) ReportMessageReceived(address domain.RelayAddress, messageT
 
 func (m mockMetrics) ReportRelayDisconnection(address domain.RelayAddress, err error) {
 }
+
+func (m mockMetrics) ReportNotice(address domain.RelayAddress, noticeType relays.NoticeType) {
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ThreeDotsLabs/watermill-googlecloud v1.0.13
 	github.com/boreq/errors v0.1.0
 	github.com/boreq/rest v0.1.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/mux v1.8.1
@@ -37,6 +36,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ThreeDotsLabs/watermill-googlecloud v1.0.13
 	github.com/boreq/errors v0.1.0
 	github.com/boreq/rest v0.1.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/mux v1.8.1
@@ -36,7 +37,6 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"reflect"
 	"runtime"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 )
@@ -200,6 +201,16 @@ func (d devNullLoggerEntry) WithField(key string, v any) Entry {
 }
 
 func (d devNullLoggerEntry) Message(msg string) {
+}
+
+// logPeriodically executes the passed action function if the current time in milliseconds
+// modulo logInterval equals zero. This approach allows executing the action periodically,
+// approximating the execution to happen once every `logInterval` milliseconds.
+func LogPeriodically(action func(), logInterval int64) {
+	currentTimeMillis := time.Now().UnixNano() / int64(time.Millisecond)
+	if currentTimeMillis%logInterval == 0 {
+		action()
+	}
 }
 
 func Inspect(args ...interface{}) {

--- a/service/adapters/mocks/metrics.go
+++ b/service/adapters/mocks/metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/planetary-social/nos-event-service/service/app"
 	"github.com/planetary-social/nos-event-service/service/domain"
+	"github.com/planetary-social/nos-event-service/service/domain/relays"
 )
 
 type Metrics struct {
@@ -37,6 +38,9 @@ func (m Metrics) ReportNumberOfStoredEvents(n int) {
 }
 
 func (m Metrics) ReportEventSentToRelay(address domain.RelayAddress, decision app.SendEventToRelayDecision, result app.SendEventToRelayResult) {
+}
+
+func (m Metrics) ReportNotice(address domain.RelayAddress, noticeType relays.NoticeType) {
 }
 
 type ApplicationCall struct {

--- a/service/domain/downloader/scheduler.go
+++ b/service/domain/downloader/scheduler.go
@@ -372,7 +372,7 @@ func (t *TimeWindowTaskGenerator) Generate(ctx context.Context, kinds []domain.E
 func (t *TimeWindowTaskGenerator) maybeGenerateNewTracker(ctx context.Context) (*TimeWindowTaskTracker, bool, error) {
 	nextWindow := t.lastWindow.Advance()
 	now := t.currentTimeProvider.GetCurrentTime()
-	if nextWindow.End().After(now.Add(-time.Minute)) {
+	if nextWindow.End().After(now.Add(-windowSize)) {
 		return nil, false, nil
 	}
 	t.lastWindow = nextWindow

--- a/service/domain/relays/relay_connection.go
+++ b/service/domain/relays/relay_connection.go
@@ -21,7 +21,6 @@ import (
 	"github.com/planetary-social/nos-event-service/service/domain/relays/transport"
 )
 
-const relayAddress = "wss://relay.nostr.com.au"
 const (
 	ReconnectionBackoff        = 5 * time.Minute
 	MaxDialReconnectionBackoff = 30 * time.Minute
@@ -88,16 +87,6 @@ func (r *RateLimitNoticeBackoffManager) Bump() {
 
 	atomic.AddInt32(&r.rateLimitNoticeCount, 1)
 	r.updateLastBumpTime()
-}
-
-// logPeriodically executes the passed action function if the current time in milliseconds
-// modulo logInterval equals zero. This approach allows executing the action periodically,
-// approximating the execution to happen once every `logInterval` milliseconds.
-func logPeriodically(action func(), logInterval int64) {
-	currentTimeMillis := time.Now().UnixNano() / int64(time.Millisecond)
-	if currentTimeMillis%logInterval == 0 {
-		action()
-	}
 }
 
 func (r *RateLimitNoticeBackoffManager) Wait() {

--- a/service/domain/relays/relay_connection_test.go
+++ b/service/domain/relays/relay_connection_test.go
@@ -257,3 +257,6 @@ func (m2 mockMetrics) ReportMessageReceived(address domain.RelayAddress, message
 
 func (m2 mockMetrics) ReportRelayDisconnection(address domain.RelayAddress, err error) {
 }
+
+func (m2 mockMetrics) ReportNotice(address domain.RelayAddress, noticeType relays.NoticeType) {
+}

--- a/service/domain/relays/relay_connections.go
+++ b/service/domain/relays/relay_connections.go
@@ -14,6 +14,7 @@ type Metrics interface {
 	ReportNumberOfSubscriptions(address domain.RelayAddress, n int)
 	ReportMessageReceived(address domain.RelayAddress, messageType MessageType, err *error)
 	ReportRelayDisconnection(address domain.RelayAddress, err error)
+	ReportNotice(address domain.RelayAddress, noticeType NoticeType)
 }
 
 type MessageType struct {
@@ -93,6 +94,7 @@ func (d *RelayConnections) storeMetrics() {
 	d.metrics.ReportRelayConnectionsState(m)
 }
 
+// Notice that a single connection can serve multiple req. This can cause a too many concurrent requests error if not throttled.
 func (r *RelayConnections) getConnection(relayAddress domain.RelayAddress) *RelayConnection {
 	r.connectionsLock.Lock()
 	defer r.connectionsLock.Unlock()


### PR DESCRIPTION
* Respects relay NOTICE warnings when sending events so we act upon then and we don't just backoff on disconnects but also from these events. I hope one day the NOTICE types are standardised.
* Adds a new prometheus metrics to inspect the NOTICE event messages
* Some small refactors and more comments to existent code