### PR TITLE
Shared rate limiter for multiple conns

### DIFF
--- a/service/domain/relay_address_test.go
+++ b/service/domain/relay_address_test.go
@@ -44,8 +44,12 @@ func TestRelayAddress(t *testing.T) {
 			Output: "wss://example.com",
 		},
 		{
+			Input:  "wss://EXAMPLE.com/FooBar ",
+			Output: "wss://example.com/FooBar",
+		},
+		{
 			Input:  "wss://example1.com/ wss://example2.com",
-			Output: "wss://example1.com/ wss://example2.com",
+			Output: "wss://example1.com/%20wss://example2.com",
 		},
 		{
 			Input:         "wss:// wss://example.com",

--- a/service/domain/relays/rate_limit_notice_backoff_manager.go
+++ b/service/domain/relays/rate_limit_notice_backoff_manager.go
@@ -1,0 +1,69 @@
+package relays
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+)
+
+type RateLimitNoticeBackoffManager struct {
+	rateLimitNoticeCount int32
+	lastBumpTime         atomic.Value
+}
+
+func NewRateLimitNoticeBackoffManager() *RateLimitNoticeBackoffManager {
+	r := &RateLimitNoticeBackoffManager{
+		rateLimitNoticeCount: 0,
+	}
+
+	r.updateLastBumpTime()
+	return r
+}
+
+func (r *RateLimitNoticeBackoffManager) Bump() {
+	timeSinceLastBump := time.Since(r.getLastBumpTime())
+	if timeSinceLastBump < 500*time.Millisecond {
+		// Give some time for the rate limit to be lifted before increasing the counter
+		return
+	}
+
+	atomic.AddInt32(&r.rateLimitNoticeCount, 1)
+	r.updateLastBumpTime()
+}
+
+const maxBackoffMs = 10000
+const secondsToDecreaseRateLimitNoticeCount = 60 * 5 // 5 minutes = 300 seconds
+
+func (r *RateLimitNoticeBackoffManager) Wait() {
+	rateLimitNoticeCount := atomic.LoadInt32(&r.rateLimitNoticeCount)
+	if rateLimitNoticeCount <= 0 {
+		return
+	}
+
+	backoffMs := int(math.Min(float64(maxBackoffMs), math.Pow(2, float64(r.rateLimitNoticeCount))*50))
+
+	timeSinceLastBump := time.Since(r.getLastBumpTime())
+	if timeSinceLastBump > secondsToDecreaseRateLimitNoticeCount*time.Second {
+		atomic.AddInt32(&r.rateLimitNoticeCount, -1)
+		r.updateLastBumpTime()
+	}
+
+	if backoffMs > 0 {
+		time.Sleep(time.Duration(backoffMs) * time.Millisecond)
+	}
+}
+
+func (r *RateLimitNoticeBackoffManager) updateLastBumpTime() time.Time {
+	t := time.Now()
+	r.lastBumpTime.Store(t)
+	return t
+}
+
+func (r *RateLimitNoticeBackoffManager) getLastBumpTime() time.Time {
+	val := r.lastBumpTime.Load()
+	if t, ok := val.(time.Time); ok {
+		return t
+	}
+
+	return r.updateLastBumpTime()
+}

--- a/service/domain/relays/relay_connection_test.go
+++ b/service/domain/relays/relay_connection_test.go
@@ -135,9 +135,10 @@ type testConnection struct {
 func newTestConnection(tb testing.TB, ctx context.Context) *testConnection {
 	connection := newMockConnection()
 	factory := newMockConnectionFactory(connection)
+	backoffManager := relays.NewRateLimitNoticeBackoffManager()
 	metrics := newMockMetrics()
 	logger := logging.NewDevNullLogger()
-	relayConnection := relays.NewRelayConnection(factory, logger, metrics)
+	relayConnection := relays.NewRelayConnection(factory, backoffManager, logger, metrics)
 	go relayConnection.Run(ctx)
 
 	return &testConnection{


### PR DESCRIPTION
This change is to unify the rate limits between relays addresses that share the same relay. Like with `wss://Foobar.com`, `wss://foobar.com/audio`, `wss://foobar.com/video`. 