### PR TITLE
Load shedding instead of disconnection under backpressure

### DIFF
--- a/service/domain/relays/relay_connection.go
+++ b/service/domain/relays/relay_connection.go
@@ -366,7 +366,6 @@ func (r *RelayConnection) run(ctx context.Context) error {
 				WithError(err).
 				WithField("message", string(messageBytes)).
 				Message("error handling an incoming message")
-			continue
 		}
 	}
 }

--- a/service/domain/relays/relay_connections.go
+++ b/service/domain/relays/relay_connections.go
@@ -76,9 +76,8 @@ func (d *RelayConnections) SendEvent(ctx context.Context, relayAddress domain.Re
 
 func (d *RelayConnections) NotifyBackPressure() {
 	for _, connection := range d.connections {
-		if connection.cancelRun != nil && connection.Address().HostWithoutPort() != "relay.nos.social" {
-			connection.cancelRun()
-			connection.cancelRun = nil
+		if connection.Address().HostWithoutPort() != "relay.nos.social" {
+			connection.setState(RelayConnectionStateBackPressured)
 		}
 	}
 }


### PR DESCRIPTION
A load shedding strategy when we are under backpressure instead of full disconnection as we currently do. Currently when we reconnect we grab 1 hour of data from each relay and that's very hard to change and integrate with the backpressure signal from the consumer. Load shedding is easier to skip that hour surge of events on reconnects and also opens the door to future more dynamic/intelligent adaptations under load.

<img width="1536" alt="Screenshot 2024-05-20 at 1 32 08 PM" src="https://github.com/planetary-social/nos-event-service/assets/18184/98651ee6-0088-42ac-a27d-a8bda11b8e10">

