### PR TITLE
Add jitter timeout, fixes and use lock

### DIFF
--- a/service/domain/relays/relay_connections.go
+++ b/service/domain/relays/relay_connections.go
@@ -75,6 +75,8 @@ func (d *RelayConnections) SendEvent(ctx context.Context, relayAddress domain.Re
 }
 
 func (d *RelayConnections) NotifyBackPressure() {
+	d.connectionsLock.Lock()
+	defer d.connectionsLock.Unlock()
 	for _, connection := range d.connections {
 		if connection.cancelRun != nil && connection.Address().HostWithoutPort() != "relay.nos.social" {
 			connection.cancelRun()
@@ -84,6 +86,8 @@ func (d *RelayConnections) NotifyBackPressure() {
 }
 
 func (d *RelayConnections) ResolveBackPressure() {
+	d.connectionsLock.Lock()
+	defer d.connectionsLock.Unlock()
 	for _, connection := range d.connections {
 		if connection.cancelBackPressure != nil {
 			connection.cancelBackPressure()

--- a/service/ports/sqlitepubsub/event_saved.go
+++ b/service/ports/sqlitepubsub/event_saved.go
@@ -57,7 +57,7 @@ func (s *EventSavedEventSubscriber) Run(ctx context.Context) error {
 					fmt.Sprintf("Queue size %d > %d. Sending backpressure signal to slow down", queueSize, backPressureThreshold),
 				)
 				s.handler.NotifyBackPressure()
-			} else if queueSize < backPressureThreshold/2 {
+			} else {
 				s.handler.ResolveBackPressure()
 			}
 


### PR DESCRIPTION
Adding timeout to resolve backpressure state, use locks when traversing connections, disable backpressure wait if main context was cancelled.